### PR TITLE
Bump `elm-community/list-extra` version.

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -14,7 +14,7 @@
     ],
     "dependencies": {
         "Bogdanp/elm-combine": "3.1.1 <= v < 4.0.0",
-        "elm-community/list-extra": "5.0.0 <= v < 6.0.0",
+	"elm-community/list-extra": "7.1.0 <= v < 8.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "rtfeldman/hex": "1.0.0 <= v < 2.0.0"
     },


### PR DESCRIPTION
Hey @tunguski! I had to move `tunguski/elm-ast` into a vendor folder because its 1list-extra` version clashes with another package I wanted to install. Everything works fine with the latest version so you'll just need to do an `elm-package bump` and `elm-package publish` and you should be good to go!

Thanks!